### PR TITLE
メール認証を追加

### DIFF
--- a/backend/build/package/.env.copy
+++ b/backend/build/package/.env.copy
@@ -1,9 +1,17 @@
 APP_URL = http://localhost:8080
+
 YOUR_CLIENT_ID = 
 YOUR_CLIENT_SECRET = 
+
 MYSQL_HOST = db
 MYSQL_USER = root
 MYSQL_PASSWORD = root
 MYSQL_DATABASE = sample_db
+
 JWT_SECRET_KEY=
 JWT_EXPIRED_TIME=24
+
+SMTP_HOST = mailhog
+SMTP_PORT = 1025
+EMAIL_ADDRESS = testadmin@example.com
+EMAIL_PASSWORD = null

--- a/backend/domain/model/user.go
+++ b/backend/domain/model/user.go
@@ -9,6 +9,8 @@ type User struct {
 	Email string `json:"email" gorm:"unique"`
 	Password string `json:"password"`
 	Name	string	`json:"name"`
+	EmailVerified     bool   `gorm:"default:false"`
+    VerificationToken string `gorm:"size:255"`
 }
 
 func hashPassword(password string) (string, error) {

--- a/backend/domain/repository/userrepository.go
+++ b/backend/domain/repository/userrepository.go
@@ -7,5 +7,6 @@ type UserRepository interface {
 	GetUserByID(uint) (model.User, error)
 	GetUserByEmail(string) (model.User, error)
 	CreateUser(*model.User) error
+	VerifyEmail(string) error
 }
 

--- a/backend/infrastructure/email/email.go
+++ b/backend/infrastructure/email/email.go
@@ -1,0 +1,48 @@
+package email
+
+import (
+	"fmt"
+	"log"
+	"net/smtp"
+	"os"
+)
+
+func SendVerificationEmail(to string, token string) error {
+	// 環境変数の値をログ出力とチェック
+	from := os.Getenv("EMAIL_ADDRESS")
+	if from == "" {
+		return fmt.Errorf("EMAIL_ADDRESS is not set")
+	}
+
+	smtpHost := os.Getenv("SMTP_HOST")
+	if smtpHost == "" {
+		return fmt.Errorf("SMTP_HOST is not set")
+	}
+
+	smtpPort := os.Getenv("SMTP_PORT")
+	if smtpPort == "" {
+		return fmt.Errorf("SMTP_PORT is not set")
+	}
+
+	log.Printf("Sending email from: %s", from)
+	log.Printf("SMTP Settings - Host: %s, Port: %s", smtpHost, smtpPort)
+
+	msg := []byte(fmt.Sprintf("From: <%s>\r\n"+
+		"To: <%s>\r\n"+
+		"Subject: Email Verification\r\n"+
+		"Content-Type: text/plain; charset=UTF-8\r\n\r\n"+
+		"Please verify your email by clicking the following link: http://localhost:8080/verify?token=%s\r\n",
+		from, to, token))
+
+	// デバッグ用にメッセージを出力
+	log.Printf("Message content:\n%s", string(msg))
+
+	err := smtp.SendMail(smtpHost+":"+smtpPort, nil, from, []string{to}, msg)
+	if err != nil {
+		log.Printf("Error sending email: %v", err)
+		return fmt.Errorf("failed to send email: %w", err)
+	}
+
+	log.Printf("Email sent successfully to %s", to)
+	return nil
+}

--- a/backend/infrastructure/persistence/user.go
+++ b/backend/infrastructure/persistence/user.go
@@ -50,8 +50,6 @@ func (up *userPersistence) CreateUser(user *model.User) error {
             return fmt.Errorf("failed to hash password: %w", err)
         }
         
-        user.Password = ""
-        
         // ユーザーの作成
         if err := tx.Create(user).Error; err != nil {
             return fmt.Errorf("failed to create user: %w", err)
@@ -59,4 +57,21 @@ func (up *userPersistence) CreateUser(user *model.User) error {
         
         return nil
     })
+}
+
+func (up *userPersistence) VerifyEmail(token string) error {
+	user := model.User{}
+	res := up.db.Session(&gorm.Session{}).Where("verification_token = ?", token).Find(&user)
+	if res.Error != nil {
+		return res.Error
+	}
+	
+	user.EmailVerified = true
+	user.VerificationToken = ""
+	
+	if err := up.db.Session(&gorm.Session{}).Save(&user).Error; err != nil {
+		return err
+	}
+	
+	return nil
 }

--- a/backend/interface/handler/registeruser.go
+++ b/backend/interface/handler/registeruser.go
@@ -1,12 +1,15 @@
 package handler
 
 import (
-	"go-cms/usecase"
-	"net/http"
 	"log"
+	"net/http"
+	"crypto/rand"
+	"encoding/hex"
 
 	"github.com/gin-gonic/gin"
 	"gorm.io/gorm"
+	"go-cms/usecase"
+	"go-cms/infrastructure/email"
 )
 
 type RegisterHandler struct {
@@ -19,22 +22,44 @@ func NewRegisterHandler(db *gorm.DB) *RegisterHandler {
 	}
 }
 
+func generateToken() (string, error) {
+	bytes := make([]byte, 16)
+	if _, err := rand.Read(bytes); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(bytes), nil
+}
+
 func (rh *RegisterHandler) Register(ctx *gin.Context) {
-	email := ctx.PostForm("email")
+	userEmail := ctx.PostForm("email")
 	password := ctx.PostForm("password")
 	name := ctx.PostForm("name")
 
-	if email == "" || password == "" || name == "" {
+	if userEmail == "" || password == "" || name == "" {
 		ctx.JSON(http.StatusBadRequest, gin.H{"error": "Email, password, and name are required"})
 		return
 	}
 
-	err := rh.RegisterUserUseCase.Register(email, password, name)
+	token, err := generateToken()
+	if err != nil {
+		log.Println(err)
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to generate verification token"})
+		return
+	}
+
+	err = email.SendVerificationEmail(userEmail, token)
+	if err != nil {
+		log.Println(err)
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to send verification email"})
+		return
+	}
+
+	err = rh.RegisterUserUseCase.Register(userEmail, password, name, token)
 	if err != nil {
 		log.Println(err)
 		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to register user"})
 		return
 	}
 
-	ctx.JSON(http.StatusOK, gin.H{"message": "User registered successfully"})
+	ctx.JSON(http.StatusOK, gin.H{"message": "User registered successfully. Please check your email to verify your account."})
 }

--- a/backend/interface/handler/router/router.go
+++ b/backend/interface/handler/router/router.go
@@ -38,7 +38,7 @@ func NewRouter(db *gorm.DB) *gin.Engine {
 		ctx.File("./ui/html/auth/register.html")
 	})
 	router.POST("/register", registerHandler.Register)
-
+	router.GET("/verify", userHandler.VerifyEmail)
 	router.POST("/logout", logoutHandler.Logout)
 	
 	authGroup := router.Group("/admin")

--- a/backend/interface/handler/user.go
+++ b/backend/interface/handler/user.go
@@ -46,3 +46,20 @@ func (uh *UserHandler) GetAllUsers(ctx *gin.Context) {
 
     ctx.JSON(http.StatusOK, users)
 }
+
+func (uh *UserHandler) VerifyEmail(ctx *gin.Context) {
+    token := ctx.Query("token")
+    if token == "" {
+        ctx.JSON(http.StatusBadRequest, gin.H{"error": "Verification token is required"})
+        return
+    }
+
+    err := uh.UserUseCase.VerifyEmail(token)
+    if err != nil {
+        log.Println(err)
+        ctx.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to verify email"})
+        return
+    }
+
+    ctx.JSON(http.StatusOK, gin.H{"message": "メール認証に成功しました。ログインページに移動してログインしてください。"})
+}

--- a/backend/ui/html/auth/register.html
+++ b/backend/ui/html/auth/register.html
@@ -121,8 +121,7 @@
             }
           })
           .then(data => {
-            alert('登録に成功しました');
-            // 登録成功後の処理をここに追加
+            alert('登録メールを送信しました');
           })
           .catch(error => {
             alert(error.message);

--- a/backend/usecase/loginusecase.go
+++ b/backend/usecase/loginusecase.go
@@ -33,6 +33,10 @@ func (uc *LoginUseCase) Login(email, password string) (string, error) {
 		return "", errors.New("invalid email or password")
 	}
 
+	if !user.EmailVerified {
+        return "", errors.New("email not verified")
+    }
+
 	if err := bcrypt.CompareHashAndPassword([]byte(user.Password), []byte(password)); err != nil {
 		return "", errors.New("invalid email or password")
 	}

--- a/backend/usecase/registeruserusecase.go
+++ b/backend/usecase/registeruserusecase.go
@@ -18,14 +18,20 @@ func NewRegisterUserUseCase(db *gorm.DB) *RegisterUserUseCase {
     }
 }
 
-func (uc *RegisterUserUseCase) Register(email, password, name string) error {
+func (uc *RegisterUserUseCase) Register(email string, password string, name string,token string) error {
     // ユーザーを作成
-    user := &model.User{
-        Email:    email,
-        Password: password,
-        Name:     name,
+    user := model.User{
+        Email: email,
+        Password: password, // パスワードはハッシュ化する必要があります
+        Name: name,
+        EmailVerified : false,
+        VerificationToken: token,
     }
 
     // ユーザーをデータベースに保存
-    return uc.UserRepo.CreateUser(user)
+    return uc.UserRepo.CreateUser(&user)
+}
+
+func (uc *UserUseCase) VerifyEmail(token string) error {
+    return uc.UserRepo.VerifyEmail(token)
 }

--- a/compose.yaml
+++ b/compose.yaml
@@ -22,5 +22,10 @@ services:
       - ./mysql/db/initdata:/docker-entrypoint-initdb.d
       - db-data:/var/lib/mysql
       - ./mysql/db/my.cnf:/etc/mysql/conf.d/my.cnf
+  mailhog:
+    image: mailhog/mailhog
+    ports:
+      - 1025:1025
+      - 8025:8025
 volumes:
   db-data:


### PR DESCRIPTION
このプルリクエストは、ユーザー登録のための新しいメール認証機能を導入し、それに関連するいくつかのコード変更を含んでいます。主な変更点は、`User`モデルへのメール認証フィールドの追加、メール送信機能の実装、および登録・ログインプロセスの更新によるメール認証の組み込みです。

### メール認証機能:

* [backend/domain/model/user.go](diffhunk://#diff-1c2af72c6f19e3890c8c51a7fb0b70ffeb50f0bb84cf915dc0cafa7787d6b168R12-R13): User構造体に`EmailVerified`および`VerificationToken`フィールドを追加。
* [backend/infrastructure/email/email.go](diffhunk://#diff-bc34cbbdd246d50c1acbae729ab85996a2e30c49453fc44fb7caa4d7c77a52f2R1-R48): SMTPを使用して認証メールを送信する`SendVerificationEmail`関数を実装。
* [backend/interface/handler/registeruser.go](diffhunk://#diff-2e79a16a69374f1e59fb94dd40dbf1f9f2263b1b96e1513429f3a5ac0a29db23R25-R64): `Register`関数を更新し、ユーザー登録時に認証トークンの生成と認証メールの送信を行うように変更。
* [backend/interface/handler/user.go](diffhunk://#diff-c49a65f610ad6711ade5b74372255fe8d845347b368b021e077d792fcf613dd3R52-R68): 認証リクエストを処理する`VerifyEmail`関数を追加。

### 登録およびログインの更新:

* [backend/usecase/registeruserusecase.go](diffhunk://#diff-12313056ca4bc87c439eebd8434a6d0db9447a6ef74839fb1d22c56bee501b0cL21-R36): `Register`関数を変更し、認証トークンを追加。新たに`VerifyEmail`関数を追加してメールアドレスの認証を実行。
* [backend/usecase/loginusecase.go](diffhunk://#diff-cabdb5c3c69ba42aaeffc1bc2e34da09bac11ec3c10005ec7898746510218145R36-R39): `Login`関数を更新し、ユーザーのメールが認証されているか確認してからログインを許可するように変更。

### 設定および環境の更新:

* [backend/build/package/.env.copy](diffhunk://#diff-055ffb267dabab8a03a625d99d12389ce59ddf600834b32f30ea41e162d2fb59R2-R17): メール送信用のSMTP設定変数を追加。
* [compose.yaml](diffhunk://#diff-facaded51b7d1c9656ae43b449b69aa398fee9129321a0001d97048c00c8cc1cR25-R29): メール送信テスト用に`mailhog`サービスを追加。

これらの変更により、ユーザーがログインする前にメールアドレスを認証する必要があるため、ユーザー登録プロセスのセキュリティと信頼性が向上します。